### PR TITLE
Correct misused TANGO_PKG_CFLAGS_OTHER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,7 @@ link_directories(${TANGO_PKG_LIBRARY_DIRS})
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${TANGO_PKG_INCLUDE_DIRS})
-target_compile_options(${PROJECT_NAME} PUBLIC -std=c++0x)
-target_compile_definitions(${PROJECT_NAME} PUBLIC ${TANGO_PKG_CFLAGS_OTHER})
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++0x ${TANGO_PKG_CFLAGS_OTHER})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${TANGO_PKG_LIBRARIES} ${CMAKE_DL_LIBS})
 
 #TODO install


### PR DESCRIPTION
Correct misused TANGO_PKG_CFLAGS_OTHER.

Currently compilation is broken on some configurations, e.g. debian buster (see https://github.com/tango-controls/cppTango/pull/633)

CFLAGS should go to `target_compile_options`, not `target_compile_definitions`.

```
root@ac1098307b6b:/tango_admin/build# pkg-config --cflags-only-other tango
-isystem /usr/include/mit-krb5
root@ac1098307b6b:/tango_admin/build# pkg-config --cflags-only-other libzmq
-isystem /usr/include/mit-krb5
root@ac1098307b6b:/tango_admin/build# make VERBOSE=1
...
/usr/bin/c++  -D-isystem -D/usr/include/mit-krb5 -I/tango_admin -I/usr/include/tango -I/usr/include/pgm-5.2  -std=c++0x -o CMakeFiles/tango_admin.dir/tango_admin.cpp.o -c /tango_admin/tango_admin.cpp
<command-line>: error: macro names must be identifiers
<command-line>: error: macro names must be identifiers
...
```

Same problem with TangoTest:
https://github.com/tango-controls/TangoTest/blob/5237cfa0fbdadc480fc38b67e4c6ba8e41e2d3bf/CMakeLists.txt#L25
